### PR TITLE
Specify required jQuery version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Bootstrap JavaScript depends on jQuery.
 If you're using Rails 5.1+, add the `jquery-rails` gem to your Gemfile:
 
 ```ruby
-gem 'jquery-rails'
+gem 'jquery-rails', '~> 4.3.1'
 ```
 
 Bootstrap tooltips and popovers depend on [popper.js] for positioning.


### PR DESCRIPTION
If we use an older version like `4.1.0` we will run into this issue: https://github.com/activeadmin/activeadmin/issues/5129

It's important to specify the version given it will use an older version if you have installed the gem previously.